### PR TITLE
use american english for pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,6 +19,6 @@ node-test-image:
     release:
       traits:
         version:
-          preprocess: 'finalise'
+          preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'


### PR DESCRIPTION
Users expect to write american english in pipeline definitions.
Therefore rename "finalise" to "finalize"