### PR TITLE
use node:10.10-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM node:alpine
+FROM node:10.10-alpine
 
 ENV PHANTOMJS_VERSION=2.1.1
 


### PR DESCRIPTION
we want to keep the node version in sync with the one used in dashboard's [dockerfile](https://github.com/gardener/dashboard/blob/master/Dockerfile)